### PR TITLE
修复rtcConnects会多一条undefined连接

### DIFF
--- a/htmlTest/webRtc.html
+++ b/htmlTest/webRtc.html
@@ -68,6 +68,7 @@
         /** WebRtc相关 */
         //构建webRtc连接并返回
         function getOrCreateRtcConnect(socketId) {
+            if (!socketId) return;
             var pc = rtcConnects[socketId];
             if (typeof (pc) == 'undefined') {
                 //构建RTCPeerConnection


### PR DESCRIPTION
修复rtcConnects会多一条undefined连接，因为这个undefined连接会导致remoteDiv下会多一块空白区域